### PR TITLE
remove emojis and clean up toml formatting

### DIFF
--- a/extension.toml
+++ b/extension.toml
@@ -17,17 +17,17 @@ languages = ["HTML", "JavaScript", "CSS"]
 "CSS" = "css"
 
 [slash_commands.live-server-start]
-description: "Start service for the current project"
+description = "Start service for the current project"
 requires_argument = false
 
 [slash_commands.live-server-stop]
-description: "Stop service for the current project"
+description = "Stop service for the current project"
 requires_argument = false
 
 [slash_commands.live-server-status]
-description: "Get the status of the service for the current project"
+description = "Get the status of the service for the current project"
 requires_argument = false
 
 [slash_commands.live-server-open]
-description: "Open the current project in the browser"
+description = "Open the current project in the browser"
 requires_argument = false

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -122,7 +122,7 @@ impl zed::Extension for LiveServerExtension {
     ) -> Result<SlashCommandOutput, String> {
         match command.name.as_str() {
             "live-server-start" => {
-                let output_text = "🚀 Starting Live Server...\n\nTo check status, use /live-server-status\nTo stop the server, use /live-server-stop";
+                let output_text = "Starting Live Server...\n\nTo check status, use /live-server-status\nTo stop the server, use /live-server-stop";
 
                 Ok(SlashCommandOutput {
                     sections: vec![SlashCommandOutputSection {
@@ -133,7 +133,7 @@ impl zed::Extension for LiveServerExtension {
                 })
             }
             "live-server-stop" => {
-                let output_text = "⏹️  Stopping Live Server...\n\nThe Live Server has been stopped.\nTo start again, use /live-server-start";
+                let output_text = "Stopping Live Server...\n\nThe Live Server has been stopped.\nTo start again, use /live-server-start";
 
                 Ok(SlashCommandOutput {
                     sections: vec![SlashCommandOutputSection {
@@ -144,7 +144,7 @@ impl zed::Extension for LiveServerExtension {
                 })
             }
             "live-server-status" => {
-                let output_text = "🌐 Opening Live Server in browser...\n\n🔗 URL: http://127.0.0.1:57391\n\nIf the browser doesn't open automatically, copy the URL above and paste it in your browser.";
+                let output_text = "Opening Live Server in browser...\n\nURL: http://127.0.0.1:57391\n\nIf the browser doesn't open automatically, copy the URL above and paste it in your browser.";
 
                 Ok(SlashCommandOutput {
                     sections: vec![SlashCommandOutputSection {
@@ -154,10 +154,10 @@ impl zed::Extension for LiveServerExtension {
                     text: output_text.to_string(),
                 })
             }
-            
+
             "live-server-open" => {
-                let output_text: &'static str = "🌐 Opening Live Server in browser...\n\n🔗 URL: http://127.0.0.1:57391\n\nIf the browser doesn't open automatically, copy the URL above and paste it in your browser.";
-                
+                let output_text: &'static str = "Opening Live Server in browser...\n\nURL: http://127.0.0.1:57391\n\nIf the browser doesn't open automatically, copy the URL above and paste it in your browser.";
+
                 Ok(SlashCommandOutput {
                     sections: vec![SlashCommandOutputSection{
                         range: (0..output_text.len()).into(),


### PR DESCRIPTION
Emojis in logging seemed to be causing issues where random text was appearing when the HTML was loaded in a browser.

I think this may also fix [#11](https://github.com/frederik-uni/zed-live-server/issues/11) 